### PR TITLE
chore: remove offical wsl clipboard solution & revert to custom workaround.

### DIFF
--- a/nvim/lua/isitayush/helpers.lua
+++ b/nvim/lua/isitayush/helpers.lua
@@ -1,4 +1,11 @@
---[=[
+--[[
+-- This is a trash workaround for copying from wsl to windows clipboard.
+-- For me (ie. with this config), pasting from windows clipboard to wsl work fine. 
+-- But copying from wsl to windows clipboard doesn't work.
+--
+-- This is a workaround for that. Also yeah, vim's solution doesn't work.
+-- Since powershell.exe causes rendering issues while pasting text.
+--]]
 function _G.copy_to_clipboard()
   -- Grab the current position
   -- getpos returns: []
@@ -26,6 +33,4 @@ end
   augroup END
   ]])
 
---]=]
--- I've never seen such multiline comments...I do have a lot of questions.
 

--- a/nvim/lua/isitayush/init.lua
+++ b/nvim/lua/isitayush/init.lua
@@ -6,19 +6,6 @@ require("isitayush.helpers")
 local augroup = vim.api.nvim_create_augroup
 local isitayush_group = augroup('isitayush', {})
 local autocmd = vim.api.nvim_create_autocmd
-local yank_group = augroup('HighlightYank', {})
-
--- Highlight yank
-autocmd('TextYankPost', {
-    group = yank_group,
-    pattern = '*',
-    callback = function()
-        vim.highlight.on_yank({
-            higroup = 'IncSearch',
-            timeout = 40,
-        })
-    end,
-})
 
 -- Autoformat on save.
 autocmd({"BufWritePre"}, {

--- a/nvim/lua/isitayush/packer.lua
+++ b/nvim/lua/isitayush/packer.lua
@@ -8,7 +8,7 @@ vim.cmd [[packadd packer.nvim]]
 
 return require('packer').startup(function(use)
   -- Packer can manage itself
-  use 'wbthomason/packer.nvim'
+  use('wbthomason/packer.nvim')
 
   -- This the finder thingy.
   use {

--- a/nvim/lua/isitayush/set.lua
+++ b/nvim/lua/isitayush/set.lua
@@ -29,19 +29,3 @@ vim.opt.signcolumn = "yes"
 vim.opt.isfname:append("@-@")
 vim.opt.updatetime = 50
 vim.api.colorcolumn = ""
-
-
--- This is the clipboard setup for WSL.
-vim.opt.clipboard = "unnamedplus"
-vim.g.clipboard = {
-    name = 'WslClipboard',
-    copy = {
-        ['+'] = 'clip.exe',
-        ['*'] = 'clip.exe',
-    },
-    paste = {
-        ['+'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-        ['*'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
-    },
-    cache_enabled = 0,
-}


### PR DESCRIPTION
The PR revert's nvim to use my custom workaround for copying & paste instead of the one described in `:help clipboard-wsl`.

`clipboard-wsl` uses powershell for paste which causes rendering issue while putting (`p`) text after copying.

By default, without any solution. Pasting from `windows --> wsl` already works natively. The only issue is copying from `wsl --> windows`. The global function `copy_to_clipboard()` defined in `helperrs.lua` is a simple workaround for it. It reads from highlighted buffer, trims & pastes it to clipboard via `clip.exe`.